### PR TITLE
fix: chunking strategy

### DIFF
--- a/workflow.py
+++ b/workflow.py
@@ -44,18 +44,33 @@ def convert_to_pdf(file_bytes: bytes, filename: str):
 
     elif extension in {"txt", "md"}:
         text = file_bytes.decode("utf-8", errors="ignore")
-        page = pdf.new_page()
-        page.insert_text((72, 72), text)
+        lines = text.splitlines()
+        pdf = fitz.open()
+        max_lines_per_page = 40  # You can adjust this limit
+
+        for i in range(0, len(lines), max_lines_per_page):
+            page = pdf.new_page()
+            chunk_text = "\n".join(lines[i:i + max_lines_per_page])
+            page.insert_text((72, 72), chunk_text)
+
         pdf.save(buffer)
         return buffer.getvalue()
 
+
     elif extension in {"doc", "docx"}:
         doc = Document(io.BytesIO(file_bytes))
-        text = "\n".join([para.text for para in doc.paragraphs])
-        page = pdf.new_page()
-        page.insert_text((72, 72), text)
+        pdf = fitz.open()
+        paragraphs = [para.text for para in doc.paragraphs]
+        max_paras_per_page = 20  # Adjustable limit
+
+        for i in range(0, len(paragraphs), max_paras_per_page):
+            page = pdf.new_page()
+            chunk_text = "\n".join(paragraphs[i:i + max_paras_per_page])
+            page.insert_text((72, 72), chunk_text)
+
         pdf.save(buffer)
         return buffer.getvalue()
+
 
     elif extension == "pptx":
         prs = Presentation(io.BytesIO(file_bytes))
@@ -81,33 +96,48 @@ def process_page(idx, ocr_response=None):
     except Exception as e:
         return f"Error processing page {idx + 1}: {e}"
 
-def extract_text_from_pdf(pdf_bytes: bytes):
+def extract_text_from_pdf(pdf_bytes: bytes, advanced: bool = True):
+    extracted_text = []
+
+    if not advanced:
+        # Simple text extraction using PyMuPDF (no OCR)
+        try:
+            with pymupdf.open(stream=pdf_bytes, filetype="pdf") as doc:
+                for page in doc:
+                    text = page.get_text()
+                    extracted_text.append(text)
+            return extracted_text
+        except Exception as e:
+            return [f"Error during simple text extraction: {e}"]
+
+    # Advanced mode: Use Mistral OCR
     try:
         with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
             total_pages = len(pdf.pages)
     except Exception:
-        with pymupdf.open(stream=pdf_bytes, filetype="pdf") as doc:
-            total_pages = len(doc)
+        try:
+            with pymupdf.open(stream=pdf_bytes, filetype="pdf") as doc:
+                total_pages = len(doc)
+        except Exception as e:
+            return [f"Error getting total pages: {e}"]
 
-    pdf_bytes = encode_pdf(pdf_bytes)
+    encoded_pdf = encode_pdf(pdf_bytes)
 
     try:
         response = client.ocr.process(
             model="mistral-ocr-latest",
             document={
                 "type": "document_url",
-                "document_url": f"data:application/pdf;base64,{pdf_bytes}"
+                "document_url": f"data:application/pdf;base64,{encoded_pdf}"
             },
             include_image_base64=True
         )
     except Exception as e:
         return [f"Error during OCR processing: {e}"]
 
-    page_numbers = list(range(total_pages))
-
-    extracted_text = []
-    for idx in page_numbers:
-        extracted_text.append(process_page(idx, ocr_response=response))
+    for idx in range(total_pages):
+        page_text = process_page(idx, ocr_response=response)
+        extracted_text.append(page_text)
         
     return extracted_text
 
@@ -117,19 +147,32 @@ def create_chunks(directory_path: str):
         for f in os.listdir(directory_path)
         if os.path.isfile(os.path.join(directory_path, f))
     ]
+    
     Chunks = []
+    
     for idx, file_path in enumerate(file_paths):
         filename = os.path.basename(file_path)
+        extension = filename.lower().split('.')[-1]
+        
         with open(file_path, "rb") as f:
             file_bytes = f.read()
         
-        print(f"📑 Converting {filename} to pdf if necessary...")
         converted_pdf_bytes = convert_to_pdf(file_bytes, filename)
-
-        print(f"📑 Extracting pages from file {filename}...")
-        pages = extract_text_from_pdf(converted_pdf_bytes)
-        for page in pages:
-            Chunks.append({"filename": filename, "page_number": idx + 1,"page_content": page})
+        print(f"Processing file: {filename}")
+        
+        # Decide mode based on file type
+        if extension in {"txt", "md"}:
+            pages = extract_text_from_pdf(converted_pdf_bytes, advanced=False)
+        else:
+            pages = extract_text_from_pdf(converted_pdf_bytes, advanced=True)
+        
+        for page_number, page in enumerate(pages, start=1):
+            Chunks.append({
+                "filename": filename,
+                "page_number": page_number,
+                "page_content": page
+            })
+    
     return Chunks
 
 def create_records(page_data: str, system_prompt: str):


### PR DESCRIPTION
PR Summary: Optimize PDF text extraction with simple and advanced modes

1. Fixed .txt and .md files to split content across multiple PDF pages instead of a single page.
2. Fixed .doc and .docx files to split paragraphs across multiple PDF pages to avoid truncation.
3. Added simple mode for text extraction without OCR to reduce Mistral API usage.
4. .txt and .md files now use simple mode automatically for faster extraction.
5. Ensures consistent page-wise output for both modes while optimizing API calls.
